### PR TITLE
Fix AssertionError at training time in vae.py (closes #191)

### DIFF
--- a/examples/vae.py
+++ b/examples/vae.py
@@ -585,7 +585,7 @@ class VAE(nn.Module):
         means, log_vars = self.encoder(sinput)
         zs = means
         if self.training:
-            zs += torch.exp(0.5 * log_vars.F) * torch.randn_like(log_vars.F)
+            zs = zs + torch.exp(0.5 * log_vars.F) * torch.randn_like(log_vars.F)
         out_cls, targets, sout = self.decoder(zs, gt_target)
         return out_cls, targets, sout, means, log_vars, zs
 


### PR DESCRIPTION
The operator `+=` will call the `__iadd__` function, which triggers a type check and fails when a PyTorch Tensor is added to a `SparseTensor`. This commit fixes this problem by using the `+` operator, which calls the `__add__` function.