### PR TITLE
fix mistypo in MinkowskiPooling: self.mode -> self.pooling_mode

### DIFF
--- a/MinkowskiEngine/MinkowskiPooling.py
+++ b/MinkowskiEngine/MinkowskiPooling.py
@@ -706,7 +706,7 @@ class MinkowskiGlobalPooling(MinkowskiModuleBase):
         )
 
     def __repr__(self):
-        return self.__class__.__name__ + f"(mode={str(self.mode)})"
+        return self.__class__.__name__ + f"(mode={str(self.pooling_mode)})"
 
 
 class MinkowskiGlobalSumPooling(MinkowskiGlobalPooling):


### PR DESCRIPTION
Fix typo error in MinkowskiPooling.py
```
self.mode -> self.pooling_mode
```