### PR TITLE
Fixed mkl build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,10 @@ if KEEP_OBJS:
 BLAS_LIST = ["openblas", "mkl", "atlas", "blas"]
 if not (BLAS is False):  # False only when not set, str otherwise
     assert BLAS in BLAS_LIST
-    libraries.append(BLAS)
+    if BLAS == "mkl":
+        libraries.append("mkl_rt")
+    else:
+        libraries.append(BLAS)
     if not (BLAS_INCLUDE_DIRS is False):
         compile_args += [f"BLAS_INCLUDE_DIRS={BLAS_INCLUDE_DIRS}"]
     if not (BLAS_LIBRARY_DIRS is False):


### PR DESCRIPTION
When linking against mkl, the current setup.py will inject "mkl" to libraries, which resulting in link command option "-lmkl" which is incorrect. As stated in [MKL documentation](https://software.intel.com/content/www/us/en/develop/articles/a-new-linking-model-single-dynamic-library-mkl_rt-since-intel-mkl-103.html), the single dynamic library object is named libmkl_rt.so, therefore the link command option should be "-lmkl_rt".