### PR TITLE
support RANDOM_SUBSAMPLE

### DIFF
--- a/MinkowskiEngine/MinkowskiSparseTensor.py
+++ b/MinkowskiEngine/MinkowskiSparseTensor.py
@@ -71,7 +71,8 @@ class SparseTensor(Tensor):
         >>> A = ME.SparseTensor(features=feats, coordinates=coords)
         >>> B = ME.SparseTensor(features=feats, coordinate_map_key=A.coordiante_map_key, coordinate_manager=A.coordinate_manager)
         >>> C = ME.SparseTensor(features=feats, coordinates=coords, quantization_mode=ME.SparseTensorQuantizationMode.UNWEIGHTED_AVERAGE)
-        >>> D = ME.SparseTensor(features=feats, coordinates=coords, tensor_stride=2)
+        >>> D = ME.SparseTensor(features=feats, coordinates=coords, quantization_mode=ME.SparseTensorQuantizationMode.RANDOM_SUBSAMPLE)
+        >>> E = ME.SparseTensor(features=feats, coordinates=coords, tensor_stride=2)
 
     .. warning::
 

--- a/MinkowskiEngine/MinkowskiTensorField.py
+++ b/MinkowskiEngine/MinkowskiTensorField.py
@@ -65,6 +65,7 @@ class TensorField(Tensor):
         assert quantization_mode in [
             SparseTensorQuantizationMode.UNWEIGHTED_AVERAGE,
             SparseTensorQuantizationMode.UNWEIGHTED_SUM,
+            SparseTensorQuantizationMode.RANDOM_SUBSAMPLE,
         ], "invalid quantization mode"
 
         # A tensor field is a shallow wrapper on a sparse tensor, but keeps the original data for element-wise operations


### PR DESCRIPTION
quantization_mode with ME.SparseTensorQuantizationMode.UNWEIGHTED_AVERAGE sometimes causes `nan` value, as the following result, detailed information can be seen [https://github.com/NVIDIA/MinkowskiEngine/issues/273](https://github.com/NVIDIA/MinkowskiEngine/issues/273)
```
SparseTensor(
coordinates=tensor([[ 0, 7, 3, 13],
[ 0, 2, -6, -13],
[ 0, -15, -1, -5],
...,
[ 0, 9, -5, 7],
[ 0, -4, -2, 12],
[ 0, -13, 6, 4]], device='cuda:0', dtype=torch.int32)
features=tensor([[ 0.0239, 0.0238, -0.0336],
[ nan, nan, nan],
[ nan, nan, nan],
...,
[ nan, nan, nan],
[ nan, nan, nan],
[ nan, nan, nan]], device='cuda:0')
coordinate_map_key=coordinate map key:[1, 1, 1]
coordinate_manager=CoordinateMapManagerGPU_c10(
[1, 1, 1]: CoordinateMapGPU:768x4
algorithm=MinkowskiAlgorithm.DEFAULT
)
spatial dimension=3)
```
I tried to replace `ME.SparseTensorQuantizationMode.UNWEIGHTED_AVERAGE` with `ME.SparseTensorQuantizationMode.RANDOM_SUBSAMPLE`. The assertion error occurs [https://github.com/NVIDIA/MinkowskiEngine/blob/v0.5/MinkowskiEngine/MinkowskiTensorField.py#L65](https://github.com/NVIDIA/MinkowskiEngine/blob/v0.5/MinkowskiEngine/MinkowskiTensorField.py#L65).

Maybe `ME.SparseTensorQuantizationMode.RANDOM_SUBSAMPLE` is ignored, so I added here. Moreover I add the `ME.SparseTensorQuantizationMode.RANDOM_SUBSAMPLE`  in the [example](https://github.com/NVIDIA/MinkowskiEngine/blob/v0.5/MinkowskiEngine/MinkowskiSparseTensor.py#L73) to provide more clear usage.