### PR TITLE
fix bug.

### DIFF
--- a/examples/resnet.py
+++ b/examples/resnet.py
@@ -186,6 +186,8 @@ class ResFieldNetBase(ResNetBase):
         ResNetBase.network_initialization(self, field_ch2, out_channels, D)
 
     def forward(self, x):
+        if not hasattr(x, '_inverse_mapping'):
+            _ = x.sparse()
         otensor = self.field_network(x)
         otensor2 = self.field_network2(otensor.cat_slice(x))
         return ResNetBase.forward(self, otensor2)


### PR DESCRIPTION
If `_inverse_mapping` missing, `cat_slice` will get an error.

```
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/envs/wypr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/ubuntu/anaconda3/envs/wypr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/data/MinkowskiEngine/examples/modelnet40.py", line 552, in <module>
    train(net, device, config)
  File "/data/MinkowskiEngine/examples/modelnet40.py", line 504, in train
    sout = net(sin)
  File "/home/ubuntu/anaconda3/envs/wypr/lib/python3.7/site-packages/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/data/MinkowskiEngine/examples/resnet.py", line 190, in forward
    otensor2 = self.field_network2(otensor.cat_slice(x))
  File "/data/MinkowskiEngine/MinkowskiEngine/MinkowskiSparseTensor.py", line 619, in cat_slice
    features = torch.cat((self.F[X.inverse_mapping], X.F), dim=1)
  File "/data/MinkowskiEngine/MinkowskiEngine/MinkowskiTensorField.py", line 266, in inverse_mapping
    "Did you run SparseTensor.slice? The slice must take a tensor field that returned TensorField.space."
ValueError: Did you run SparseTensor.slice? The slice must take a tensor field that returned TensorField.space.
```
