### PR TITLE
fix to_sparse function

### DIFF
--- a/MinkowskiEngine/MinkowskiOps.py
+++ b/MinkowskiEngine/MinkowskiOps.py
@@ -209,7 +209,7 @@ def to_sparse(dense_tensor: torch.Tensor, coordinates: torch.Tensor = None):
     return SparseTensor(
         feat_tensor.reshape(-1, dense_tensor.size(1)),
         coordinates,
-        device=dense_tensor.dtype,
+        device=dense_tensor.device,
     )
 
 


### PR DESCRIPTION
I tried to convert a dense torch tensor stored on a GPU to a sparse one using `ME.to_sparse()` and it failed with

`AssertionError: Features and coordinates must have the same backend.` 

I found that there was a typo.