### PR TITLE
Remove has_bias (v0.4) references from tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ class ExampleNetwork(ME.MinkowskiNetwork):
                 kernel_size=3,
                 stride=2,
                 dilation=1,
-                has_bias=False,
+                bias=False,
                 dimension=D),
             ME.MinkowskiBatchNorm(64),
             ME.MinkowskiReLU())

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -19,7 +19,7 @@ conv = ME.MinkowskiConvolution(
     kernel_size=7,
     stride=1,
     dilation=1,
-    has_bias=False,
+    bias=False,
     dimension=3)
 ```
 
@@ -53,7 +53,7 @@ net = nn.Sequential(
         kernel_size=5,
         stride=1,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=3),
     ME.MinkowskiConvolution(
         in_channels=32,
@@ -61,7 +61,7 @@ net = nn.Sequential(
         kernel_size=2,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=3),
     ME.MinkowskiConvolutionTranspose
         in_channels=32,
@@ -69,7 +69,7 @@ net = nn.Sequential(
         kernel_size=2,
         stride=2,
         dilation=1,
-        has_bias=False,
+        bias=False,
         dimension=3))
 ```
 

--- a/examples/convolution.py
+++ b/examples/convolution.py
@@ -56,7 +56,7 @@ def conv():
         out_channels,
         kernel_size=3,
         stride=2,
-        has_bias=False,
+        bias=False,
         dimension=D)
 
     output = conv(input)
@@ -79,7 +79,7 @@ def conv():
         out_channels,
         kernel_size=3,
         stride=2,
-        has_bias=False,
+        bias=False,
         dimension=D)
     output = conv_tr(input)
 
@@ -109,7 +109,7 @@ def conv_on_coords():
         out_channels,
         kernel_size=3,
         stride=2,
-        has_bias=False,
+        bias=False,
         dimension=D)
 
     pool_tr = ME.MinkowskiPoolingTranspose(

--- a/tests/python/chwise_conv.py
+++ b/tests/python/chwise_conv.py
@@ -61,7 +61,7 @@ class TestConvolution(unittest.TestCase):
             in_channels,
             kernel_size=3,
             stride=1,
-            has_bias=False,
+            bias=False,
             dimension=D).double()
 
         print('Initial input: ', input)
@@ -90,7 +90,7 @@ class TestConvolution(unittest.TestCase):
             in_channels,
             kernel_size=3,
             stride=1,
-            has_bias=False,
+            bias=False,
             dimension=D).double().to(device)
 
         print('Initial input: ', input)

--- a/tests/python/conv_on_coords.py
+++ b/tests/python/conv_on_coords.py
@@ -65,7 +65,7 @@ class TestConvolution(unittest.TestCase):
             out_channels,
             kernel_size=3,
             stride=1,
-            has_bias=False,
+            bias=False,
             dimension=D).double()
 
         print('Initial input: ', input)
@@ -103,7 +103,7 @@ class TestConvolution(unittest.TestCase):
             out_channels,
             kernel_size=3,
             stride=2,
-            has_bias=False,
+            bias=False,
             dimension=D).double()
         print('Initial input: ', input)
         print('Specified output coords: ', out_coords)


### PR DESCRIPTION
The `has_bias` sparse convolution argument was still present from version `0.4`, this is now removed from all tests and examples and docs.