### PR TITLE
fix bug of device detect in batched_coordinates

### DIFF
--- a/MinkowskiEngine/utils/collation.py
+++ b/MinkowskiEngine/utils/collation.py
@@ -121,7 +121,7 @@ def sparse_collate(coords, feats, labels=None, dtype=torch.int32, device=None):
     assert len(D) == 1, f"Dimension of the array mismatch. All dimensions: {D}"
     D = D[0]
     if device is None:
-        if isinstance(coords, torch.Tensor):
+        if isinstance(coords[0], torch.Tensor):
             device = coords[0].device
         else:
             device = "cpu"


### PR DESCRIPTION
**coords** in **batched_coordinates** is a sequence of tensor: _List(tensor)_, while the device is none, we should check the device of one of the coords.