### PR TITLE
Remove PyTorch version from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,6 @@ libraries = []
 CC_FLAGS = []
 NVCC_FLAGS = []
 
-TORCH_VERSION = [int(v) for v in torch.__version__.replace('+', '.').split('.')[:3]]
-
 if CPU_ONLY:
     print("--------------------------------")
     print("| WARNING: CPU_ONLY build set  |")


### PR DESCRIPTION
The `TORCH_VERSION` was not used and led to breaking the install when PyTorch was custom built. Tested with CUDA 11.2 and PyTorch 1.9.0.