### PR TITLE
Fix Darwin&CPU build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,15 +53,16 @@ try:
 except ImportError:
     raise ImportError("Pytorch not found. Please install pytorch first.")
 
-import warnings
 import codecs
 import os
 import re
 import subprocess
-from sys import argv, platform
-from setuptools import setup
-from torch.utils.cpp_extension import CppExtension, CUDAExtension, BuildExtension
+import warnings
 from pathlib import Path
+from sys import argv, platform
+
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 
 if platform == "win32":
     raise ImportError("Windows is currently not supported.")
@@ -172,7 +173,7 @@ else:
     CC_FLAGS += ["-fopenmp"]
 
 if "darwin" in platform:
-    CC_FLAGS += ["-stdlib=libc++"]
+    CC_FLAGS += ["-stdlib=libc++", "-std=c++17"]
 
 NVCC_FLAGS += ["--expt-relaxed-constexpr", "--expt-extended-lambda"]
 FAST_MATH, argv = _argparse("--fast_math", argv)

--- a/src/coordinate_map_cpu.hpp
+++ b/src/coordinate_map_cpu.hpp
@@ -84,7 +84,7 @@ field_map_kernel(uint32_t const num_tfield,      //
     uint32_t curr_index_begin;
 
     for (auto i = stride * n;
-         i < std::min((n + 1) * stride, uint64_t(num_tfield)); ++i) {
+         i < std::min<uint64_t>((n + 1) * stride, uint64_t(num_tfield)); ++i) {
 
       // batch index
       curr_vec[0] = std::lroundf(p_tfield[i * coordinate_size]);
@@ -181,7 +181,7 @@ std::vector<at::Tensor> interpolation_map_weight_kernel(
     uint32_t curr_index_begin;
 
     for (auto i = stride * n;
-         i < std::min((n + 1) * stride, uint64_t(num_tfield)); ++i) {
+         i < std::min<uint64_t>((n + 1) * stride, uint64_t(num_tfield)); ++i) {
 
       // batch index
       curr_vec[0] = std::lroundf(p_tfield[i * coordinate_size]);
@@ -1006,7 +1006,7 @@ public:
 #pragma omp parallel for
       for (uint32_t n = 0; n < N; n++) {
         for (auto i = stride * n;
-             i < std::min((n + 1) * stride, uint64_t(size())); ++i) {
+             i < std::min<uint64_t>((n + 1) * stride, uint64_t(size())); ++i) {
 
           // batch index
           coordinate_int_type *p_curr_dst =
@@ -1021,7 +1021,7 @@ public:
 #pragma omp parallel for
       for (uint32_t n = 0; n < N; n++) {
         for (auto i = stride * n;
-             i < std::min((n + 1) * stride, uint64_t(size())); ++i) {
+             i < std::min<uint64_t>((n + 1) * stride, uint64_t(size())); ++i) {
 
           // batch index
           coordinate_int_type *p_curr_dst =

--- a/src/coordinate_map_manager.cpp
+++ b/src/coordinate_map_manager.cpp
@@ -1343,7 +1343,8 @@ CoordinateMapManager<coordinate_type, coordinate_field_type, TemplatedAllocator,
     ASSERT(false, ERROR_CPU_ONLY);
 #endif
   }
-  at::Tensor coordinates = torch::empty({(long)nrows, (long)ncols}, options);
+  at::Tensor coordinates =
+      torch::empty({(int64_t)nrows, (int64_t)ncols}, options);
 
   LOG_DEBUG("Initialized coordinates");
   // copy to the out coords
@@ -1371,7 +1372,7 @@ struct kernel_map_to_tensors<coordinate_type, std::allocator, CoordinateMapCPU,
     for (auto k = 0; k < in_maps.size(); ++k) {
       const auto &in_map = in_maps[k];
       const auto &out_map = out_maps[k];
-      const long N = in_map.size();
+      const int64_t N = in_map.size();
       if (N > 0) {
         at::Tensor kernel_map = torch::empty({2, N}, options);
         int32_t *p_kernel_map = kernel_map.data_ptr<int32_t>();
@@ -1439,7 +1440,8 @@ at::Tensor CoordinateMapManager<coordinate_type, coordinate_field_type,
     ASSERT(false, ERROR_CPU_ONLY);
 #endif
   }
-  at::Tensor coordinates = torch::empty({(long)nrows, (long)ncols}, options);
+  at::Tensor coordinates =
+      torch::empty({(int64_t)nrows, (int64_t)ncols}, options);
 
   // copy to the out coords
   map.copy_coordinates(coordinates.template data_ptr<coordinate_field_type>());

--- a/src/pooling_avg_kernel.hpp
+++ b/src/pooling_avg_kernel.hpp
@@ -156,7 +156,7 @@ template void NonzeroAvgPoolingForwardKernelCPU<float, int>(
     cpu_out_maps const &out_maps, //
     int const out_nrows, bool const use_avg);
 
-template void NonzeroAvgPoolingForwardKernelCPU<float, long>(
+template void NonzeroAvgPoolingForwardKernelCPU<float, int64_t>(
     float const *p_in_feat, float *p_out_feat, float *p_num_nonzero,
     int const nchannel,
     cpu_in_maps const &in_maps,   //
@@ -169,7 +169,7 @@ template void NonzeroAvgPoolingForwardKernelCPU<double, int>(
     cpu_out_maps const &out_maps, //
     int const out_nrows, bool const use_avg);
 
-template void NonzeroAvgPoolingForwardKernelCPU<double, long>(
+template void NonzeroAvgPoolingForwardKernelCPU<double, int64_t>(
     double const *p_in_feat, double *p_out_feat, double *p_num_nonzero,
     int const nchannel,
     cpu_in_maps const &in_maps,   //

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -161,7 +161,8 @@ std::vector<std::vector<int>> quantize_label(int const *const p_coords,
                                                   >;
   using value_type = map_type::value_type;
 
-  auto map = map_type{nrows, hasher{ncols}, key_equal{ncols}};
+  auto map = map_type{(size_t)nrows, hasher{(uint32_t)ncols},
+                      key_equal{(size_t)ncols}};
 
   LOG_DEBUG("Map nrows:", nrows, "ncols:", ncols);
   // insert_row

--- a/src/quantization.cpp
+++ b/src/quantization.cpp
@@ -269,18 +269,18 @@ std::vector<at::Tensor> quantize_label_th(at::Tensor coords, at::Tensor labels,
   // Copy the concurrent vector to std vector
   //
   // Long tensor for for easier indexing
-  auto th_mapping = torch::empty({(long)mapping.size()},
+  auto th_mapping = torch::empty({(int64_t)mapping.size()},
                                  torch::TensorOptions().dtype(torch::kInt64));
-  auto a_th_mapping = th_mapping.accessor<long int, 1>();
+  auto a_th_mapping = th_mapping.accessor<int64_t, 1>();
 
   auto th_inverse_mapping =
-      torch::empty({(long)inverse_mapping.size()},
+      torch::empty({(int64_t)inverse_mapping.size()},
                    torch::TensorOptions().dtype(torch::kInt64));
-  auto a_th_inverse_mapping = th_inverse_mapping.accessor<long int, 1>();
+  auto a_th_inverse_mapping = th_inverse_mapping.accessor<int64_t, 1>();
 
-  auto th_colabels = torch::empty({(long)colabels.size()},
+  auto th_colabels = torch::empty({(int64_t)colabels.size()},
                                   torch::TensorOptions().dtype(torch::kInt64));
-  auto a_th_colabels = th_colabels.accessor<long int, 1>();
+  auto a_th_colabels = th_colabels.accessor<int64_t, 1>();
 
   // Copy the output
   for (size_t i = 0; i < mapping.size(); ++i)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -47,7 +47,7 @@ struct timer {
         .count();
   }
 
-  std::chrono::system_clock::time_point m_start;
+  std::chrono::high_resolution_clock::time_point m_start;
 };
 
 template <typename T>


### PR DESCRIPTION
Build for Darwin platform and CPU-only has been broken for a long time, now it is fixed and should work by simply running `--cpu-only` or having no GPU and using `--blas=mkl` for acceleration.

- [x] The below issue is solved as well on Mac machines using `clang`:
```
Python 3.8.11 (default, Sep 23 2021, 14:53:39)
[Clang 10.0.0 ] :: Intel Corporation on darwin
Type "help", "copyright", "credits" or "license" for more information.
Intel(R) Distribution for Python is brought to you by Intel Corporation.
Please check out: https://software.intel.com/en-us/python-distribution
>>> import MinkowskiEngine as ME
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/x/opt/anaconda3/envs/y/lib/python3.8/site-packages/MinkowskiEngine-0.5.4-py3.8-macosx-10.9-x86_64.egg/MinkowskiEngine/__init__.py", line 53, in <module>
    from MinkowskiEngineBackend._C import (
ImportError: dlopen(/Users/x/opt/anaconda3/envs/y/lib/python3.8/site-packages/MinkowskiEngine-0.5.4-py3.8-macosx-10.9-x86_64.egg/MinkowskiEngineBackend/_C.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZNK2at10TensorBase8data_ptrIlEEPT_v'
```

Tested with both `torch` versions `1.10` and current master. This PR fixes https://github.com/NVIDIA/MinkowskiEngine/issues/106.