### PR TITLE
Update quantization.py

### DIFF
--- a/MinkowskiEngine/utils/quantization.py
+++ b/MinkowskiEngine/utils/quantization.py
@@ -281,7 +281,7 @@ def sparse_quantize(
             )
         else:
             assert (
-                not discrete_coordinates.is_cuda()
+                not discrete_coordinates.is_cuda
             ), "Quantization with label requires cpu tensors."
             assert not labels.is_cuda(), "Quantization with label requires cpu tensors."
             unique_map, inverse_map, colabels = MEB.quantize_label_th(


### PR DESCRIPTION
torch.Tensor.is_cuda is an attribute, not a function
this pr will solve the TypeError when calling `sparse_quantize` when using torch.Tensor as input
![image](https://user-images.githubusercontent.com/51397242/169657470-58426f1a-4258-4c69-b86c-6cd98524bb5c.png)
