### PR TITLE
Fix: stride and coord on different devices

### DIFF
--- a/MinkowskiEngine/MinkowskiSparseTensor.py
+++ b/MinkowskiEngine/MinkowskiSparseTensor.py
@@ -402,7 +402,7 @@ class SparseTensor(Tensor):
                     raise ValueError("Feature type not supported.")
 
         # Use int tensor for all operations
-        tensor_stride = torch.IntTensor(self.tensor_stride)
+        tensor_stride = torch.IntTensor(self.tensor_stride).to(self.C.device)
 
         # New coordinates
         coords = self.C


### PR DESCRIPTION
Fix the bug *min_coords* and *tensor_stride* on different devices and raise an error on line 414.
A better solution is to assign value to *self.device* even if it is None in *self.__init__*? Then we can make all new tensors can be generated on the specific device directly, instead of *.to()*.