### PR TITLE
Fix python 3.10 breaking change

### DIFF
--- a/MinkowskiEngine/MinkowskiCommon.py
+++ b/MinkowskiEngine/MinkowskiCommon.py
@@ -22,7 +22,7 @@
 # Please cite "4D Spatio-Temporal ConvNets: Minkowski Convolutional Neural
 # Networks", CVPR'19 (https://arxiv.org/abs/1904.08755) if you use any part
 # of the code.
-from collections import Sequence
+from collections.abc import Sequence
 import numpy as np
 from typing import Union
 

--- a/MinkowskiEngine/MinkowskiCoordinateManager.py
+++ b/MinkowskiEngine/MinkowskiCoordinateManager.py
@@ -24,7 +24,7 @@
 # of the code.
 import os
 import numpy as np
-from collections import Sequence
+from collections.abc import Sequence
 from typing import Union, List, Tuple
 import warnings
 

--- a/MinkowskiEngine/MinkowskiKernelGenerator.py
+++ b/MinkowskiEngine/MinkowskiKernelGenerator.py
@@ -23,7 +23,8 @@
 # Networks", CVPR'19 (https://arxiv.org/abs/1904.08755) if you use any part
 # of the code.
 import math
-from collections import Sequence, namedtuple
+from collections import namedtuple
+from collections.abc import Sequence
 from functools import reduce
 import numpy as np
 from typing import Union

--- a/MinkowskiEngine/MinkowskiTensorField.py
+++ b/MinkowskiEngine/MinkowskiTensorField.py
@@ -23,7 +23,7 @@
 # of the code.
 import os
 import numpy as np
-from collections import Sequence
+from collections.abc import Sequence
 from typing import Union, List, Tuple
 
 import torch

--- a/MinkowskiEngine/utils/quantization.py
+++ b/MinkowskiEngine/utils/quantization.py
@@ -23,7 +23,7 @@
 # of the code.
 import torch
 import numpy as np
-from collections import Sequence
+from collections.abc import Sequence
 import MinkowskiEngineBackend._C as MEB
 from typing import Union, Tuple
 from MinkowskiCommon import convert_to_int_list


### PR DESCRIPTION
`collections.Sequence` was moved to `collections.abc.Sequence` for python 3 and the deprecated aliases were removed in python 3.10.