### PR TITLE
Fix compilation error (pytorch 1.11.0, cuda 11.6)

### DIFF
--- a/src/spmm.cu
+++ b/src/spmm.cu
@@ -29,6 +29,7 @@
 
 #include <cusparse.h>
 
+#include <ATen/core/Tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/CUDAUtils.h>
 #include <c10/cuda/CUDACachingAllocator.h>


### PR DESCRIPTION
Compilation failed for `src/spmm.cu` with 

```
/usr/include/c10/util/ArrayRef.h(142): error: expression must be a pointer to a complete object
 type
          detected during instantiation of "c10::ArrayRef<T>::iterator c10::ArrayRef<T>::end()
const [with T=at::Tensor]"
/usr/include/ATen/cuda/CUDAUtils.h(14): here

/usr/include/ATen/cuda/CUDAUtils.h(15): error: incomplete class type "at::Tensor" is not allowed

/usr/include/ATen/NamedTensorUtils.h(14): error: no instance of function template "std::any_of"
 matches the argument list
            argument types are: (const at::Tensor *, <error-type>, lambda [](const at::Tensor &
)->__nv_bool)
```

for pytorch 1.11.0 with cuda 11.6.

Fixes #453