### PR TITLE
fix sparse_quantize to work with int coordinates

### DIFF
--- a/MinkowskiEngine/utils/quantization.py
+++ b/MinkowskiEngine/utils/quantization.py
@@ -130,6 +130,8 @@ def _auto_floor(array):
     if isinstance(array, np.ndarray):
         return np.floor(array)
     else:
+        if array.dtype == torch.int32 or array.dtype == torch.int64:
+            return array
         return torch.floor(array)
 
 


### PR DESCRIPTION
Do not call `torch.floor` on int tensors as it returns `RuntimeError: "floor_cuda" not implemented for 'Int'` or `RuntimeError: "floor" "_vml_cpu" not implemented for 'Int'`.
