### PR TITLE
fixed some typos during walk through using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ docker build -t minkowski_engine docker
 Once the docker is built, check it loads MinkowskiEngine correctly.
 
 ```
-docker run MinkowskiEngine python3 -c "import MinkowskiEngine; print(MinkowskiEngine.__version__)"
+docker run minkowski_engine python3 -c "import MinkowskiEngine; print(MinkowskiEngine.__version__)"
 ```
 
 ## CPU only build and BLAS configuration (MKL)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,3 +28,4 @@ RUN rm -rf /var/lib/apt/lists/*
 ENV MAX_JOBS=4
 RUN git clone --recursive "https://github.com/NVIDIA/MinkowskiEngine"
 RUN cd MinkowskiEngine; python setup.py install --force_cuda --blas=openblas
+ENV OMP_NUM_THREADS=16


### PR DESCRIPTION
* fix a README typo in  docker section
* Add a default `OPM_NUM_THREADS` to silence the docker warning. 