### PR TITLE
Fix --install-option is deprecated for pip >= v22.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,16 @@ pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps \
 #                           \ # uncomment the following line if you want to force no cuda installation. force_cuda supercedes cpu_only
 #                           --install-option="--cpu_only" \
 #                           \ # uncomment the following line to override to openblas, atlas, mkl, blas
-#                           --install-option="--blas=openblas" \
+#                           --install-option="--blas=openblas"
+
+# For pip version >= 23.2.1 (--install-option is deprecated)
+pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps \
+#                           \ # uncomment the following line if you want to force cuda installation
+#                           --config-settings="--build-option=--force_cuda" \
+#                           \ # uncomment the following line if you want to force no cuda installation. force_cuda supercedes cpu_only
+#                           --config-settings="--build-option=--cpu_only" \
+#                           \ # uncomment the following line to override to openblas, atlas, mkl, blas
+#                           --config-settings="--build-option=--blas=openblas"
 ```
 
 ### Anaconda
@@ -128,6 +137,8 @@ export CXX=g++-7
 # Uncomment the following line to specify the cuda home. Make sure `$CUDA_HOME/nvcc --version` is 10.2
 # export CUDA_HOME=/usr/local/cuda-10.2
 pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps --install-option="--blas_include_dirs=${CONDA_PREFIX}/include" --install-option="--blas=openblas"
+# For pip version >= 23.2.1 (--install-option is deprecated)
+pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps --config-settings="--build-option=--blas_include_dirs=${CONDA_PREFIX}/include" --config-settings="--build-option=--blas=openblas"
 
 # Or if you want local MinkowskiEngine
 git clone https://github.com/NVIDIA/MinkowskiEngine.git
@@ -153,6 +164,8 @@ conda install pytorch=1.9.0 torchvision cudatoolkit=11.1 -c pytorch -c nvidia
 # Uncomment the following line to specify the cuda home. Make sure `$CUDA_HOME/nvcc --version` is 11.X
 # export CUDA_HOME=/usr/local/cuda-11.1
 pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps --install-option="--blas_include_dirs=${CONDA_PREFIX}/include" --install-option="--blas=openblas"
+# For pip version >= 23.2.1 (--install-option is deprecated)
+pip install -U git+https://github.com/NVIDIA/MinkowskiEngine -v --no-deps --config-settings="--build-option=--blas_include_dirs=${CONDA_PREFIX}/include" --config-settings="--build-option=--blas=openblas"
 
 # Or if you want local MinkowskiEngine
 git clone https://github.com/NVIDIA/MinkowskiEngine.git


### PR DESCRIPTION
Hi @chrischoy:

I found that "--install-option" is deprecated for pip >= v22.3, and we can replace the argument with "--config-settings="--build-option=*". I hope this PR can make users install MinkowskiEngine easier.